### PR TITLE
Upgraded version of SwiftyJSON to v17.0.0.

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -47,7 +47,7 @@
       "package": "SwiftyJSON",
       "reason": null,
       "repositoryURL": "https://github.com/IBM-Swift/SwiftyJSON.git",
-      "version": "16.0.0"
+      "version": "17.0.0"
     }
   ],
   "version": 1

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
 	name: "BluemixPushNotifications",
     dependencies: [
         .Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-http-client-swift.git", majorVersion: 0, minor: 7),
-        .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 16)
+        .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 17)
     ]
 )


### PR DESCRIPTION
Upgraded version of SwiftyJSON to v17.0.0 for compatibility with the latest version of Kitura. This change will avoid compilation issues when using this library and the latest version of Kitura.