### PR TITLE
Update HTTP Client to 0.9.X

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
 	name: "IBMPushNotifications",
     dependencies: [
-        .Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-http-client-swift.git", majorVersion: 0, minor: 8),
+        .Package(url: "https://github.com/ibm-bluemix-mobile-services/bluemix-simple-http-client-swift.git", majorVersion: 0, minor: 9),
         .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 17)
     ]
 )


### PR DESCRIPTION
After the release of Kitura 2.3, HTTP Client got update to `0.9`. 